### PR TITLE
Removing unused trainers

### DIFF
--- a/constants/trainer_constants.asm
+++ b/constants/trainer_constants.asm
@@ -72,7 +72,6 @@ KRIS EQU __enum__
 	const WILL1
 
 	trainerclass CAL ; c
-	const CAL1
 	const CAL2
 	const CAL3
 
@@ -182,8 +181,6 @@ KRIS EQU __enum__
 	const MICHELLE
 	const DANA1
 	const ELLEN
-	const CONNIE2
-	const CONNIE3
 	const DANA2
 	const DANA3
 	const DANA4
@@ -205,12 +202,8 @@ KRIS EQU __enum__
 	const GAVEN3
 	const BLAKE
 	const BRIAN
-	const ERICK
-	const ANDY
-	const TYLER
 	const SEAN
 	const KEVIN
-	const STEVE
 	const ALLEN
 	const DARIN
 
@@ -240,19 +233,8 @@ KRIS EQU __enum__
 	trainerclass BEAUTY ; 1d
 	const VICTORIA
 	const SAMANTHA
-	const JULIE
-	const JACLYN
-	const BRENDA
 	const CASSIE
-	const CAROLINE
-	const CARLENE
-	const JESSICA
-	const RACHAEL
-	const ANGELICA
-	const KENDRA
-	const VERONICA
 	const JULIA
-	const THERESA
 	const VALERIE
 	const OLIVIA
 
@@ -285,7 +267,6 @@ KRIS EQU __enum__
 	const GRUNTM_9
 	const GRUNTM_10
 	const GRUNTM_11
-	const GRUNTM_12
 	const GRUNTM_13
 	const GRUNTM_14
 	const GRUNTM_15
@@ -295,22 +276,16 @@ KRIS EQU __enum__
 	const GRUNTM_19
 	const GRUNTM_20
 	const GRUNTM_21
-	const GRUNTM_22
-	const GRUNTM_23
 	const GRUNTM_24
 	const GRUNTM_25
-	const GRUNTM_26
-	const GRUNTM_27
 	const GRUNTM_28
 	const GRUNTM_29
-	const GRUNTM_30
 	const GRUNTM_31
 
 	trainerclass GENTLEMAN ; 20
 	const PRESTON
 	const EDWARD
 	const GREGORY
-	const VIRGIL
 	const ALFRED
 
 	trainerclass SKIER ; 21
@@ -382,18 +357,10 @@ KRIS EQU __enum__
 	const BERKE
 	const KIRK
 	const MATHEW
-	const HAL
-	const PATON
-	const DARYL
-	const WALTER
-	const TONY
 	const JEROME
 	const TUCKER
-	const RICK
 	const CAMERON
 	const SETH
-	const JAMES
-	const LEWIS
 	const PARKER
 
 	trainerclass SWIMMERF ; 27
@@ -404,15 +371,9 @@ KRIS EQU __enum__
 	const DENISE
 	const KARA
 	const WENDY
-	const LISA
-	const JILL
-	const MARY
-	const KATIE
 	const DAWN
-	const TARA
 	const NICOLE
 	const LORI
-	const JODY
 	const NIKKI
 	const DIANA
 	const BRIANA
@@ -435,16 +396,11 @@ KRIS EQU __enum__
 	trainerclass SUPER_NERD ; 29
 	const STAN
 	const ERIC
-	const GREGG
-	const JAY
-	const DAVE
 	const SAM
 	const TOM
 	const PAT
 	const SHAWN
 	const TERU
-	const RUSS
-	const NORTON
 	const HUGH
 	const MARKUS
 
@@ -485,8 +441,6 @@ KRIS EQU __enum__
 	const ANTHONY5
 
 	trainerclass BIKER ; 2d
-	const BIKER_BENNY
-	const KAZU
 	const DWAYNE
 	const HARRIS
 	const ZEKE
@@ -505,8 +459,6 @@ KRIS EQU __enum__
 
 	trainerclass FIREBREATHER ; 30
 	const OTIS
-	const DICK
-	const NED
 	const BURT
 	const BILL
 	const WALT
@@ -517,14 +469,9 @@ KRIS EQU __enum__
 	const IRWIN1
 	const FRITZ
 	const HORTON
-	const IRWIN2
-	const IRWIN3
-	const IRWIN4
 
 	trainerclass BLACKBELT_T ; 32
-	const KENJI1
 	const YOSHI
-	const KENJI2
 	const LAO
 	const NOB
 	const KIYO
@@ -589,15 +536,9 @@ KRIS EQU __enum__
 	const LLOYD
 	const DEAN
 	const SID
-	const HARVEY
-	const DALE
 	const TED
 	const TODD2
 	const TODD3
-	const THOMAS
-	const LEROY
-	const DAVID
-	const JOHN
 	const JERRY
 	const SPENCER
 	const TODD4
@@ -625,7 +566,6 @@ KRIS EQU __enum__
 	trainerclass MEDIUM ; 39
 	const MARTHA
 	const GRACE
-	const BETHANY
 	const MARGRET
 	const ETHEL
 	const REBECCA

--- a/data/trainers/parties.asm
+++ b/data/trainers/parties.asm
@@ -214,13 +214,6 @@ WillGroup:
 
 
 PKMNTrainerGroup:
-	; CAL (1)
-	db "CAL@", TRAINERTYPE_NORMAL
-	db 10, CHIKORITA
-	db 10, CYNDAQUIL
-	db 10, TOTODILE
-	db -1 ; end
-
 	; CAL (2)
 	db "CAL@", TRAINERTYPE_NORMAL
 	db 30, BAYLEEF
@@ -780,16 +773,6 @@ LassGroup:
 	db 34, GRANBULL
 	db -1 ; end
 
-	; LASS (12)
-	db "CONNIE@", TRAINERTYPE_NORMAL
-	db 21, MARILL
-	db -1 ; end
-
-	; LASS (13)
-	db "CONNIE@", TRAINERTYPE_NORMAL
-	db 21, MARILL
-	db -1 ; end
-
 	; LASS (14)
 	db "DANA@", TRAINERTYPE_MOVES
 	db 21, FLAAFFY,    TACKLE, GROWL, THUNDERSHOCK, THUNDER_WAVE
@@ -904,27 +887,6 @@ CooltrainerMGroup:
 	db 35, SANDSLASH,  SAND_ATTACK, POISON_STING, SLASH, SWIFT
 	db -1 ; end
 
-	; COOLTRAINERM (13)
-	db "ERICK@", TRAINERTYPE_NORMAL
-	db 10, BULBASAUR
-	db 10, CHARMANDER
-	db 10, SQUIRTLE
-	db -1 ; end
-
-	; COOLTRAINERM (14)
-	db "ANDY@", TRAINERTYPE_NORMAL
-	db 10, BULBASAUR
-	db 10, CHARMANDER
-	db 10, SQUIRTLE
-	db -1 ; end
-
-	; COOLTRAINERM (15)
-	db "TYLER@", TRAINERTYPE_NORMAL
-	db 10, BULBASAUR
-	db 10, CHARMANDER
-	db 10, SQUIRTLE
-	db -1 ; end
-
 	; COOLTRAINERM (16)
 	db "SEAN@", TRAINERTYPE_NORMAL
 	db 35, FLAREON
@@ -937,13 +899,6 @@ CooltrainerMGroup:
 	db 38, RHYHORN
 	db 35, CHARMELEON
 	db 35, WARTORTLE
-	db -1 ; end
-
-	; COOLTRAINERM (18)
-	db "STEVE@", TRAINERTYPE_NORMAL
-	db 14, BULBASAUR
-	db 14, CHARMANDER
-	db 14, SQUIRTLE
 	db -1 ; end
 
 	; COOLTRAINERM (19)
@@ -1103,62 +1058,10 @@ BeautyGroup:
 	db 16, MEOWTH,     SCRATCH, GROWL, BITE, SLASH
 	db -1 ; end
 
-	; BEAUTY (3)
-	db "JULIE@", TRAINERTYPE_NORMAL
-	db 15, SENTRET
-	db -1 ; end
-
-	; BEAUTY (4)
-	db "JACLYN@", TRAINERTYPE_NORMAL
-	db 15, SENTRET
-	db -1 ; end
-
-	; BEAUTY (5)
-	db "BRENDA@", TRAINERTYPE_NORMAL
-	db 16, FURRET
-	db -1 ; end
-
 	; BEAUTY (6)
 	db "CASSIE@", TRAINERTYPE_NORMAL
 	db 28, VILEPLUME
 	db 34, BUTTERFREE
-	db -1 ; end
-
-	; BEAUTY (7)
-	db "CAROLINE@", TRAINERTYPE_NORMAL
-	db 30, MARILL
-	db 32, SEEL
-	db 30, MARILL
-	db -1 ; end
-
-	; BEAUTY (8)
-	db "CARLENE@", TRAINERTYPE_NORMAL
-	db 15, SENTRET
-	db -1 ; end
-
-	; BEAUTY (9)
-	db "JESSICA@", TRAINERTYPE_NORMAL
-	db 15, SENTRET
-	db -1 ; end
-
-	; BEAUTY (10)
-	db "RACHAEL@", TRAINERTYPE_NORMAL
-	db 15, SENTRET
-	db -1 ; end
-
-	; BEAUTY (11)
-	db "ANGELICA@", TRAINERTYPE_NORMAL
-	db 15, SENTRET
-	db -1 ; end
-
-	; BEAUTY (12)
-	db "KENDRA@", TRAINERTYPE_NORMAL
-	db 15, SENTRET
-	db -1 ; end
-
-	; BEAUTY (13)
-	db "VERONICA@", TRAINERTYPE_NORMAL
-	db 15, SENTRET
 	db -1 ; end
 
 	; BEAUTY (14)
@@ -1166,11 +1069,6 @@ BeautyGroup:
 	db 32, PARAS
 	db 32, EXEGGCUTE
 	db 35, PARASECT
-	db -1 ; end
-
-	; BEAUTY (15)
-	db "THERESA@", TRAINERTYPE_NORMAL
-	db 15, SENTRET
 	db -1 ; end
 
 	; BEAUTY (16)
@@ -1341,11 +1239,6 @@ GruntMGroup:
 	db 25, RATTATA
 	db -1 ; end
 
-	; GRUNTM (12)
-	db "EXECUTIVE@", TRAINERTYPE_NORMAL
-	db 33, HOUNDOUR
-	db -1 ; end
-
 	; GRUNTM (13)
 	db "GRUNT@", TRAINERTYPE_NORMAL
 	db 27, RATTATA
@@ -1402,16 +1295,6 @@ GruntMGroup:
 	db 18, RATTATA
 	db -1 ; end
 
-	; GRUNTM (22)
-	db "EXECUTIVE@", TRAINERTYPE_NORMAL
-	db 36, GOLBAT
-	db -1 ; end
-
-	; GRUNTM (23)
-	db "EXECUTIVE@", TRAINERTYPE_NORMAL
-	db 30, KOFFING
-	db -1 ; end
-
 	; GRUNTM (24)
 	db "GRUNT@", TRAINERTYPE_NORMAL
 	db 25, KOFFING
@@ -1424,17 +1307,6 @@ GruntMGroup:
 	db 24, MUK
 	db -1 ; end
 
-	; GRUNTM (26)
-	db "GRUNT@", TRAINERTYPE_NORMAL
-	db 15, RATTATA
-	db 15, RATTATA
-	db -1 ; end
-
-	; GRUNTM (27)
-	db "EXECUTIVE@", TRAINERTYPE_NORMAL
-	db 22, ZUBAT
-	db -1 ; end
-
 	; GRUNTM (28)
 	db "GRUNT@", TRAINERTYPE_NORMAL
 	db 19, RATICATE
@@ -1444,13 +1316,6 @@ GruntMGroup:
 	db "GRUNT@", TRAINERTYPE_NORMAL
 	db  9, RATTATA
 	db  9, RATTATA
-	db -1 ; end
-
-	; GRUNTM (30)
-	db "GRUNT@", TRAINERTYPE_NORMAL
-	db 25, GOLBAT
-	db 25, GOLBAT
-	db 30, ARBOK
 	db -1 ; end
 
 	; GRUNTM (31)
@@ -1475,11 +1340,6 @@ GentlemanGroup:
 	db "GREGORY@", TRAINERTYPE_NORMAL
 	db 37, PIKACHU
 	db 33, FLAAFFY
-	db -1 ; end
-
-	; GENTLEMAN (4)
-	db "VIRGIL@", TRAINERTYPE_NORMAL
-	db 20, PONYTA
 	db -1 ; end
 
 	; GENTLEMAN (5)
@@ -1865,40 +1725,6 @@ SwimmerMGroup:
 	db 23, KRABBY
 	db -1 ; end
 
-	; SWIMMERM (9)
-	db "HAL@", TRAINERTYPE_NORMAL
-	db 24, SEEL
-	db 25, DEWGONG
-	db 24, SEEL
-	db -1 ; end
-
-	; SWIMMERM (10)
-	db "PATON@", TRAINERTYPE_NORMAL
-	db 26, PILOSWINE
-	db 26, PILOSWINE
-	db -1 ; end
-
-	; SWIMMERM (11)
-	db "DARYL@", TRAINERTYPE_NORMAL
-	db 24, SHELLDER
-	db 25, CLOYSTER
-	db 24, SHELLDER
-	db -1 ; end
-
-	; SWIMMERM (12)
-	db "WALTER@", TRAINERTYPE_NORMAL
-	db 15, HORSEA
-	db 15, HORSEA
-	db 20, SEADRA
-	db -1 ; end
-
-	; SWIMMERM (13)
-	db "TONY@", TRAINERTYPE_NORMAL
-	db 13, STARYU
-	db 18, STARMIE
-	db 16, HORSEA
-	db -1 ; end
-
 	; SWIMMERM (14)
 	db "JEROME@", TRAINERTYPE_NORMAL
 	db 26, SEADRA
@@ -1913,13 +1739,6 @@ SwimmerMGroup:
 	db 34, CLOYSTER
 	db -1 ; end
 
-	; SWIMMERM (16)
-	db "RICK@", TRAINERTYPE_NORMAL
-	db 13, STARYU
-	db 18, STARMIE
-	db 16, HORSEA
-	db -1 ; end
-
 	; SWIMMERM (17)
 	db "CAMERON@", TRAINERTYPE_NORMAL
 	db 34, MARILL
@@ -1930,20 +1749,6 @@ SwimmerMGroup:
 	db 29, QUAGSIRE
 	db 29, OCTILLERY
 	db 32, QUAGSIRE
-	db -1 ; end
-
-	; SWIMMERM (19)
-	db "JAMES@", TRAINERTYPE_NORMAL
-	db 13, STARYU
-	db 18, STARMIE
-	db 16, HORSEA
-	db -1 ; end
-
-	; SWIMMERM (20)
-	db "LEWIS@", TRAINERTYPE_NORMAL
-	db 13, STARYU
-	db 18, STARMIE
-	db 16, HORSEA
 	db -1 ; end
 
 	; SWIMMERM (21)
@@ -1996,34 +1801,9 @@ SwimmerFGroup:
 	db 21, HORSEA,     DRAGON_RAGE, SMOKESCREEN, LEER, WATER_GUN
 	db -1 ; end
 
-	; SWIMMERF (8)
-	db "LISA@", TRAINERTYPE_NORMAL
-	db 28, JYNX
-	db -1 ; end
-
-	; SWIMMERF (9)
-	db "JILL@", TRAINERTYPE_NORMAL
-	db 28, DEWGONG
-	db -1 ; end
-
-	; SWIMMERF (10)
-	db "MARY@", TRAINERTYPE_NORMAL
-	db 20, SEAKING
-	db -1 ; end
-
-	; SWIMMERF (11)
-	db "KATIE@", TRAINERTYPE_NORMAL
-	db 33, DEWGONG
-	db -1 ; end
-
 	; SWIMMERF (12)
 	db "DAWN@", TRAINERTYPE_NORMAL
 	db 34, SEAKING
-	db -1 ; end
-
-	; SWIMMERF (13)
-	db "TARA@", TRAINERTYPE_NORMAL
-	db 20, SEAKING
 	db -1 ; end
 
 	; SWIMMERF (14)
@@ -2037,11 +1817,6 @@ SwimmerFGroup:
 	db "LORI@", TRAINERTYPE_NORMAL
 	db 32, STARMIE
 	db 32, STARMIE
-	db -1 ; end
-
-	; SWIMMERF (16)
-	db "JODY@", TRAINERTYPE_NORMAL
-	db 20, SEAKING
 	db -1 ; end
 
 	; SWIMMERF (17)
@@ -2158,24 +1933,6 @@ SuperNerdGroup:
 	db 11, GRIMER
 	db -1 ; end
 
-	; SUPER_NERD (3)
-	db "GREGG@", TRAINERTYPE_NORMAL
-	db 20, MAGNEMITE
-	db 20, MAGNEMITE
-	db 20, MAGNEMITE
-	db -1 ; end
-
-	; SUPER_NERD (4)
-	db "JAY@", TRAINERTYPE_NORMAL
-	db 22, KOFFING
-	db 22, KOFFING
-	db -1 ; end
-
-	; SUPER_NERD (5)
-	db "DAVE@", TRAINERTYPE_NORMAL
-	db 24, DITTO
-	db -1 ; end
-
 	; SUPER_NERD (6)
 	db "SAM@", TRAINERTYPE_NORMAL
 	db 34, GRIMER
@@ -2207,18 +1964,6 @@ SuperNerdGroup:
 	db 11, VOLTORB
 	db  7, MAGNEMITE
 	db  9, MAGNEMITE
-	db -1 ; end
-
-	; SUPER_NERD (11)
-	db "RUSS@", TRAINERTYPE_NORMAL
-	db 27, MAGNEMITE
-	db 27, MAGNEMITE
-	db 27, MAGNEMITE
-	db -1 ; end
-
-	; SUPER_NERD (12)
-	db "NORTON@", TRAINERTYPE_MOVES
-	db 30, PORYGON,    CONVERSION, CONVERSION2, RECOVER, TRI_ATTACK
 	db -1 ; end
 
 	; SUPER_NERD (13)
@@ -2456,20 +2201,6 @@ HikerGroup:
 
 
 BikerGroup:
-	; BIKER (1)
-	db "BENNY@", TRAINERTYPE_NORMAL
-	db 20, KOFFING
-	db 20, KOFFING
-	db 20, KOFFING
-	db -1 ; end
-
-	; BIKER (2)
-	db "KAZU@", TRAINERTYPE_NORMAL
-	db 20, KOFFING
-	db 20, KOFFING
-	db 20, KOFFING
-	db -1 ; end
-
 	; BIKER (3)
 	db "DWAYNE@", TRAINERTYPE_NORMAL
 	db 27, KOFFING
@@ -2555,18 +2286,6 @@ FirebreatherGroup:
 	db 29, MAGMAR
 	db -1 ; end
 
-	; FIREBREATHER (2)
-	db "DICK@", TRAINERTYPE_NORMAL
-	db 17, CHARMELEON
-	db -1 ; end
-
-	; FIREBREATHER (3)
-	db "NED@", TRAINERTYPE_NORMAL
-	db 15, KOFFING
-	db 16, GROWLITHE
-	db 15, KOFFING
-	db -1 ; end
-
 	; FIREBREATHER (4)
 	db "BURT@", TRAINERTYPE_NORMAL
 	db 32, KOFFING
@@ -2622,51 +2341,11 @@ JugglerGroup:
 	db 33, ELECTRODE
 	db -1 ; end
 
-	; JUGGLER (4)
-	db "IRWIN@", TRAINERTYPE_NORMAL
-	db  6, VOLTORB
-	db 10, VOLTORB
-	db 14, VOLTORB
-	db 18, VOLTORB
-	db -1 ; end
-
-	; JUGGLER (5)
-	db "IRWIN@", TRAINERTYPE_NORMAL
-	db 18, VOLTORB
-	db 22, VOLTORB
-	db 26, VOLTORB
-	db 30, ELECTRODE
-	db -1 ; end
-
-	; JUGGLER (6)
-	db "IRWIN@", TRAINERTYPE_NORMAL
-	db 18, VOLTORB
-	db 22, VOLTORB
-	db 26, VOLTORB
-	db 30, ELECTRODE
-	db -1 ; end
-
 
 BlackbeltGroup:
-	; BLACKBELT_T (1)
-	db "KENJI@", TRAINERTYPE_NORMAL
-	db 27, ONIX
-	db 30, HITMONLEE
-	db 27, ONIX
-	db 32, MACHOKE
-	db -1 ; end
-
 	; BLACKBELT_T (2)
 	db "YOSHI@", TRAINERTYPE_MOVES
 	db 27, HITMONLEE,  DOUBLE_KICK, MEDITATE, JUMP_KICK, FOCUS_ENERGY
-	db -1 ; end
-
-	; BLACKBELT_T (3)
-	db "KENJI@", TRAINERTYPE_MOVES
-	db 33, ONIX,       BIND, ROCK_THROW, TOXIC, DIG
-	db 38, MACHAMP,    HEADBUTT, SWAGGER, THUNDERPUNCH, VITAL_THROW
-	db 33, STEELIX,    EARTHQUAKE, ROCK_THROW, IRON_TAIL, SANDSTORM
-	db 36, HITMONLEE,  DOUBLE_TEAM, HI_JUMP_KICK, MUD_SLAP, SWIFT
 	db -1 ; end
 
 	; BLACKBELT_T (4)
@@ -3013,16 +2692,6 @@ CamperGroup:
 	db 29, POLIWRATH
 	db -1 ; end
 
-	; CAMPER (9)
-	db "HARVEY@", TRAINERTYPE_NORMAL
-	db 15, NIDORINO
-	db -1 ; end
-
-	; CAMPER (10)
-	db "DALE@", TRAINERTYPE_NORMAL
-	db 15, NIDORINO
-	db -1 ; end
-
 	; CAMPER (11)
 	db "TED@", TRAINERTYPE_NORMAL
 	db 17, MANKEY
@@ -3040,38 +2709,6 @@ CamperGroup:
 	db 23, GEODUDE
 	db 23, GEODUDE
 	db 26, PSYDUCK
-	db -1 ; end
-
-	; CAMPER (14)
-	db "THOMAS@", TRAINERTYPE_NORMAL
-	db 33, GRAVELER
-	db 36, GRAVELER
-	db 40, GOLBAT
-	db 42, GOLDUCK
-	db -1 ; end
-
-	; CAMPER (15)
-	db "LEROY@", TRAINERTYPE_NORMAL
-	db 33, GRAVELER
-	db 36, GRAVELER
-	db 40, GOLBAT
-	db 42, GOLDUCK
-	db -1 ; end
-
-	; CAMPER (16)
-	db "DAVID@", TRAINERTYPE_NORMAL
-	db 33, GRAVELER
-	db 36, GRAVELER
-	db 40, GOLBAT
-	db 42, GOLDUCK
-	db -1 ; end
-
-	; CAMPER (17)
-	db "JOHN@", TRAINERTYPE_NORMAL
-	db 33, GRAVELER
-	db 36, GRAVELER
-	db 40, GOLBAT
-	db 42, GOLDUCK
 	db -1 ; end
 
 	; CAMPER (18)
@@ -3216,11 +2853,6 @@ MediumGroup:
 	db "GRACE@", TRAINERTYPE_NORMAL
 	db 20, HAUNTER
 	db 20, HAUNTER
-	db -1 ; end
-
-	; MEDIUM (3)
-	db "BETHANY@", TRAINERTYPE_NORMAL
-	db 25, HAUNTER
 	db -1 ; end
 
 	; MEDIUM (4)


### PR DESCRIPTION
I'm not sure if this is the sort of thing you'd want for your optimization branch, but I was doing it anyway so might as well pass it along.  :+1: 

I updated the numbers on the rosters for everything except the Rocket grunts.  They don't have names to make constant naming easy to start with, so simply skipping numbers and leaving them alone seems the easiest.